### PR TITLE
fix(#24): todo forigi resolves each reference independently

### DIFF
--- a/src/A_organizi/cli/todo.py
+++ b/src/A_organizi/cli/todo.py
@@ -315,33 +315,53 @@ def forigi(
         help=tr_multi("Todo UUID aŭ titolo (pluraj). Ekz: todo forigi #abc123 #def456", "Todo UUID or title (multiple). E.g. todo delete #abc123 #def456", "UUID ou titre du todo (plusieurs). Ex: todo supprimer #abc123 #def456"),
     )],
 ) -> None:
-    """Forigi taskon laŭ UUID aŭ titolo."""
+    """Forigi taskojn laŭ UUID aŭ titolo."""
     svc = get_todo_service()
     entries = svc.list_with_labels(limit=200)
-    item = resolve_reference(
-        entries,
-        referencoj,
-        text_getter=lambda i: str(i.get("titolo") or ""),
-        kind_label="todo",
-        allow_fuzzy=True,
-        interactive=True,
-    )
-    if item is None:
-        error(f"Todo ne trovita: {referencoj}")
-        raise typer.Exit(1)
 
-    uid = str(item.get("uuid") or "")
-    rendered = render_text(str(item.get("titolo") or ""))
-    answer = typer.prompt(
-        f"Forigi todo #{uid[:8]} \"{rendered}\"? (j/N)",
-        default="N",
-    )
-    if answer.strip().lower() not in {"j", "jes", "y", "yes"}:
-        info("Nuligita.")
-        return
+    deleted = 0
+    errors: list[tuple[str, str]] = []
 
-    svc.delete(uid, soft=False)
-    info(f"Forigis todo #{uid[:8]}.")
+    for ref in referencoj:
+        item = resolve_reference(
+            entries,
+            ref,
+            text_getter=lambda i: str(i.get("titolo") or ""),
+            kind_label="todo",
+            allow_fuzzy=True,
+            interactive=True,
+        )
+        if item is None:
+            errors.append((ref, tr_multi("ne trovita", "not found", "non trouvé")))
+            continue
+
+        uid = str(item.get("uuid") or "")
+        rendered = render_text(str(item.get("titolo") or ""))
+        answer = typer.prompt(
+            f"Forigi todo #{uid[:8]} \"{rendered}\"? (j/N)",
+            default="N",
+        )
+        if answer.strip().lower() not in {"j", "jes", "y", "yes"}:
+            info(tr_multi(f"Preterlasis {ref}.", f"Skipped {ref}.", f"Ignoré {ref}."))
+            continue
+
+        svc.delete(uid, soft=False)
+        deleted += 1
+        entries = [e for e in entries if str(e.get("uuid") or "") != uid]
+        info(f"Forigis todo #{uid[:8]}.")
+
+    # Report resolution errors
+    for ref, reason in errors:
+        error(tr_multi(
+            "Forigi {i}: {r}", "Delete {i}: {r}", "Supprimer {i} : {r}",
+        ).format(i=ref, r=reason))
+
+    if deleted:
+        info(tr_multi(
+            f"Forigis {deleted} el {len(referencoj)} todo.",
+            f"Deleted {deleted} of {len(referencoj)} todos.",
+            f"Supprimé {deleted} sur {len(referencoj)} todos.",
+        ))
 
 
 @todo_app.command()

--- a/tests/test_todo.py
+++ b/tests/test_todo.py
@@ -383,7 +383,46 @@ class TestTodoCLI:
             app, ["todo", "forigi", "Konservota"], input="N\n"
         )
         assert result.exit_code == 0
-        assert "Nuligita" in result.output
+        assert "preterlasis" in result.output.lower() or "skipped" in result.output.lower()
+
+    def test_forigi_multiple_confirmed(self):
+        """Delete multiple tasks with confirmation."""
+        from typer.testing import CliRunner
+        from A_organizi.cli import app
+
+        runner = CliRunner()
+        runner.invoke(app, ["todo", "aldoni", "Unua forigota", "-P", "10"])
+        runner.invoke(app, ["todo", "aldoni", "Dua forigota", "-P", "20"])
+        result = runner.invoke(
+            app, ["todo", "forigi", "Unua forigota", "Dua forigota"], input="j\nj\n"
+        )
+        assert result.exit_code == 0, result.output
+        assert "Forigis 2" in result.output or "Deleted 2" in result.output
+
+    def test_forigi_multiple_mixed(self):
+        """Delete multiple: one confirmed, one cancelled."""
+        from typer.testing import CliRunner
+        from A_organizi.cli import app
+
+        runner = CliRunner()
+        runner.invoke(app, ["todo", "aldoni", "Jese", "-P", "10"])
+        runner.invoke(app, ["todo", "aldoni", "Nea", "-P", "20"])
+        result = runner.invoke(
+            app, ["todo", "forigi", "Jese", "Nea"], input="j\nN\n"
+        )
+        assert result.exit_code == 0, result.output
+        assert "Forigis 1" in result.output or "Deleted 1" in result.output
+        assert "preterlasis" in result.output.lower() or "skipped" in result.output.lower()
+
+    def test_forigi_nonexistent(self):
+        """Delete a non-existent reference reports error."""
+        from typer.testing import CliRunner
+        from A_organizi.cli import app
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["todo", "forigi", "neekzistanta"])
+        assert result.exit_code == 0
+        assert "ne trovita" in result.output.lower() or "not found" in result.output.lower()
 
     def test_serci(self):
         """Search tasks."""


### PR DESCRIPTION
## What

Fixes `todo forigi` to resolve and confirm each reference independently instead of passing the entire list to `resolve_reference()`.

## Why

Fixes #24 — the old code passed `list[str]` to `resolve_reference()` which only resolved the first item. All subsequent references were silently ignored.

## How

- Iterates each reference independently via `resolve_reference`
- Per-item confirmation prompt (existing UX preserved)
- Summary: `Forigis X el Y todo.`
- Resolution errors reported gracefully, continue with remaining
- Rebuilds entries list after each deletion to prevent stale lookups

## Verification

- 194 tests pass
- User-simulation: 2-item delete with both confirmed, mixed confirm/cancel, and nonexistent reference