### PR TITLE
fix: add _db_instance singleton caching to get_db()

### DIFF
--- a/src/A_organizi/data/storage.py
+++ b/src/A_organizi/data/storage.py
@@ -11,6 +11,8 @@ from A.data.base import SQLiteDB, backup_db, health_check
 _DATA_DIR: Path = data_dir()
 _DB_FILE: Path = _DATA_DIR / "organizi.db"
 
+_db_instance: SQLiteDB | None = None
+
 # ──────────────────────────────────────────────────────────────────────────────
 # Calendars (kalendaro)
 # ──────────────────────────────────────────────────────────────────────────────
@@ -170,7 +172,20 @@ def ensure_dirs() -> None:
 
 
 def get_db() -> SQLiteDB:
-    """Get database connection with all tables and indexes created."""
+    """Get or create the shared database connection (singleton).
+
+    All callers within the same process share one ``SQLiteDB`` instance,
+    which uses one cached SQLite connection. This avoids WAL/SHM conflicts
+    that occur when multiple connections access the same database file.
+
+    The connection is lazily created on first call and cached in
+    ``_db_instance``. Tests can reset the singleton by setting
+    ``A_organizi.data.storage._db_instance = None`` in their teardown.
+    """
+    global _db_instance
+    if _db_instance is not None:
+        return _db_instance
+
     ensure_dirs()
     if not health_check(_DB_FILE):
         from A.data.base import repair_db as _repair
@@ -183,6 +198,7 @@ def get_db() -> SQLiteDB:
     for stmt in _CREATE_INDEXES:
         db.execute(stmt)
 
+    _db_instance = db
     return db
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,5 +10,11 @@ def isolate_organizi(monkeypatch, tmp_path):
     """Isolate database to tmp_path to prevent real data pollution."""
     import A_organizi.data.storage as storage_module
 
+    # Reset singleton to force fresh connection on each test
+    storage_module._db_instance = None
+
     monkeypatch.setattr(storage_module, "_DATA_DIR", tmp_path)
     monkeypatch.setattr(storage_module, "_DB_FILE", tmp_path / "organizi.db")
+
+    # Redirect ALL A-core paths to tmp_path (prevents LinksDB etc. hitting real ~/.local/share/A/)
+    monkeypatch.setenv("A_DIR", str(tmp_path))

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -176,6 +176,14 @@ class TestSchema:
         assert result is not None
         assert "wal" in str(result.get("journal_mode", "")).lower()
 
+    def test_get_db_is_singleton(self, mock_data_dir):
+        """Verify get_db() returns the same instance on repeated calls."""
+        from A_organizi.data.storage import get_db
+
+        db1 = get_db()
+        db2 = get_db()
+        assert db1 is db2
+
 
 # ──────────────────────────────────────────────────────────────────────────────
 # CRUDService integration tests


### PR DESCRIPTION
Closes #26

Same fix as A-vorto commit a13afda: get_db() created a new SQLiteDB connection on every call, causing WAL/SHM conflicts when multiple connections accessed the same database file concurrently.

Changes:
- Added _db_instance global with fast-path singleton return
- Updated conftest to reset singleton + set A_DIR env var
- Added test_get_db_is_singleton test

All 195 tests pass.