### PR TITLE
fix: replace raw pip install with ensure_dependency('A_lien', 'A-lien')

### DIFF
--- a/src/A_organizi/cli/okazajo_retposto.py
+++ b/src/A_organizi/cli/okazajo_retposto.py
@@ -199,22 +199,11 @@ def _get_evento_db():
 
 def _prompt_install_alien() -> None:
     """Prompt user to install A-lien if missing."""
-    confirm_text = tr_multi(
-        "A-lien estas bezonata por --retposto. Ĉu instali ĝin nun?",
-        "A-lien is required for --retposto. Install it now?",
-        "A-lien est requis pour --retposto. Installer maintenant ?",
-    )
-    answer = typer.confirm(confirm_text, default=True)
-    if not answer:
-        raise typer.Exit(1)
+    from A.utils.deps import ensure_dependency
 
-    import subprocess
-    import sys
     try:
-        subprocess.check_call(
-            [sys.executable, "-m", "pip", "install", "A-lien"],
-        )
-    except subprocess.CalledProcessError:
+        ensure_dependency("A_lien", "A-lien")
+    except ImportError:
         error(tr_multi(
             "Ne povis instali A-lien.",
             "Could not install A-lien.",

--- a/tests/test_retposto_ics.py
+++ b/tests/test_retposto_ics.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 from unittest.mock import Mock, patch
 
 import pytest
+import typer
 
 SAMPLE_ICS = """BEGIN:VCALENDAR
 VERSION:2.0
@@ -373,3 +374,23 @@ class TestImportIcsFromMessages:
         )
         assert "msg-empty" not in result
         assert "msg-ics" in result
+
+
+class TestPromptInstallAlien:
+    """_prompt_install_alien delegates to ensure_dependency."""
+
+    def test_calls_ensure_dependency(self) -> None:
+        """Calls ensure_dependency('A_lien', 'A-lien')."""
+        from A_organizi.cli.okazajo_retposto import _prompt_install_alien
+
+        with patch("A.utils.deps.ensure_dependency") as mock_ed:
+            _prompt_install_alien()
+            mock_ed.assert_called_once_with("A_lien", "A-lien")
+
+    def test_import_error_raises_exit(self) -> None:
+        """Raises typer.Exit(1) when ensure_dependency fails."""
+        from A_organizi.cli.okazajo_retposto import _prompt_install_alien
+
+        with patch("A.utils.deps.ensure_dependency", side_effect=ImportError("fail")):
+            with pytest.raises(typer.Exit, match="1"):
+                _prompt_install_alien()


### PR DESCRIPTION
Replace `subprocess.check_call([sys.executable, -m, pip, install, A-lien])` with `A.utils.deps.ensure_dependency('A_lien', 'A-lien')` for uv-first priority install.

- Remove inline subprocess/sys imports (no longer needed)
- Add tests: delegation, ImportError → typer.Exit(1)

Refs: #16