### PR TITLE
feat(todo): add ls command, strip # from UUID, use Rich Panel for vidi

### DIFF
--- a/src/A_organizi/cli/__init__.py
+++ b/src/A_organizi/cli/__init__.py
@@ -10,6 +10,7 @@ from A_organizi.cli.kalendaro import kalendaro_app
 from A_organizi.cli.okazajo import okazajo_app
 from A_organizi.cli.taglibro import taglibro_app
 from A_organizi.cli.todo import todo_app
+import A_organizi.cli.todo_crud  # noqa: F401 — triggers @todo_app.command() registration
 
 app = typer.Typer(
     name="organizi",

--- a/src/A_organizi/cli/todo.py
+++ b/src/A_organizi/cli/todo.py
@@ -1,17 +1,19 @@
-"""CLI commands for todo (tasks)."""
+"""CLI commands for todo (tasks) — app, helpers, and aldoni.
+
+CRUD commands (ls, vidi, modifi, forigi, serci) are in todo_crud.py.
+"""
 
 from __future__ import annotations
 
-from typing import Annotated, Optional
+from typing import Optional
 
 import typer
 
-from A import error, info, tr_multi, tr_multi
+from A import error, info, tr_multi
 from A.utils.output import console, print_table
 from A.utils.normalize import fold_search_text
 
 from A_organizi.priority import (
-    compute_priority,
     format_priority,
     priority_filter_description,
     validate_formula,
@@ -21,7 +23,6 @@ from A_organizi.utils.labels import (
     normalize_markdown_links,
     render_markdown_links_plain as render_text,
     resolve_etikedo_refs,
-    resolve_reference,
 )
 
 todo_app = typer.Typer(
@@ -38,7 +39,6 @@ todo_app = typer.Typer(
 
 def _print_results(items: list[dict]) -> None:
     """Print tasks using A-core generic table utility."""
-    # Pre-process data for table display
     rows = []
     for item in items:
         priority = format_priority(
@@ -49,7 +49,7 @@ def _print_results(items: list[dict]) -> None:
             render_text(text) for _, text in (item.get("etikedoj") or []) if text
         ) or "-"
         rows.append({
-            "uuid": f"#{str(item.get('uuid') or '')[:8]}",
+            "uuid": f"{str(item.get('uuid') or '')[:8]}",
             "titolo": render_text(str(item.get("titolo") or "")),
             "prioritato": priority,
             "stato": str(item.get("stato") or ""),
@@ -68,7 +68,10 @@ def _print_results(items: list[dict]) -> None:
 
 
 def _show_detail(item: dict) -> None:
-    """Print full details of a single task."""
+    """Print full details of a single task using a Rich Panel."""
+    from rich.panel import Panel
+    from rich.text import Text
+
     priority = format_priority(
         str(item.get("prioritato") or "0"),
         str(item.get("kreita_je") or ""),
@@ -76,18 +79,39 @@ def _show_detail(item: dict) -> None:
     etikedoj = ", ".join(
         render_text(text) for _, text in (item.get("etikedoj") or []) if text
     ) or "-"
-    typer.echo(f"uuid: #{str(item.get('uuid') or '')[:8]}")
-    typer.echo(
-        f"titolo: {render_text(str(item.get('titolo') or ''), show_ref=True)}"
+
+    uid = str(item.get("uuid") or "")[:8]
+    titolo_raw = str(item.get("titolo") or "")
+    priskribo_raw = str(item.get("priskribo") or "")
+    stato = str(item.get("stato") or "")
+    kreita = str(item.get("kreita_je", ""))
+    modifita = str(item.get("modifita_je", ""))
+
+    display_title = titolo_raw[:40] + "…" if len(titolo_raw) > 40 else titolo_raw
+    title = Text()
+    title.append(display_title, style="bold white")
+    title.append(f"  {uid}", style="dim")
+
+    lines: list[str] = []
+    lines.append(f"[bold]titolo:[/] {render_text(titolo_raw, show_ref=True)}")
+    if priskribo_raw:
+        lines.append(f"[bold]priskribo:[/] {render_text(priskribo_raw, show_ref=True)}")
+    lines.append(f"[bold]stato:[/] {stato}")
+    lines.append(f"[bold]prioritato:[/] {priority}")
+    lines.append(f"[bold]etikedoj:[/] {etikedoj}")
+    lines.append("")
+    lines.append(f"[dim]kreita_je:[/] {kreita}")
+    lines.append(f"[dim]modifita_je:[/] {modifita}")
+
+    content = "\n".join(lines)
+    panel = Panel(
+        content,
+        title=title,
+        title_align="left",
+        border_style="dim",
+        padding=(0, 1),
     )
-    typer.echo(
-        f"priskribo: {render_text(str(item.get('priskribo') or ''), show_ref=True)}"
-    )
-    typer.echo(f"stato: {str(item.get('stato') or '')}")
-    typer.echo(f"prioritato: {priority}")
-    typer.echo(f"etikedoj: {etikedoj}")
-    typer.echo(f"kreita_je: {str(item.get('kreita_je', ''))}")
-    typer.echo(f"modifita_je: {str(item.get('modifita_je', ''))}")
+    console.print(panel)
 
 
 # ── Commands ─────────────────────────────────────────────────────────────────
@@ -138,7 +162,6 @@ def aldoni(
         raise typer.Exit(1)
     priskribo_text = normalize_markdown_links(priskribo).strip()
 
-    # Validate priority formula
     if not validate_formula(prioritato):
         error(f"Nevalida prioritata formulo: {prioritato!r}")
         raise typer.Exit(1)
@@ -167,287 +190,9 @@ def aldoni(
         raise typer.Exit(1) from exc
 
     info(
-        f"Aldonis todo #{result['uuid'][:8]}: "
+        f"Aldonis todo {result['uuid'][:8]}: "
         f"{render_text(titolo_text, show_ref=True)}"
     )
 
 
-@todo_app.command()
-def vidi(
-    referenco: str = typer.Argument(
-        ...,
-        help=tr_multi("Todo UUID aŭ titolo. Ekz: todo vidi #abc123", "Todo UUID or title. E.g. todo view #abc123", "UUID ou titre du todo. Ex: todo voir #abc123"),
-    ),
-) -> None:
-    """Montri unu taskon laŭ UUID aŭ titolo."""
-    svc = get_todo_service()
-    entries = svc.list_with_labels(limit=200)
-    item = resolve_reference(
-        entries,
-        referenco,
-        text_getter=lambda i: str(i.get("titolo") or ""),
-        kind_label="todo",
-        allow_fuzzy=True,
-        interactive=True,
-    )
-    if item is None:
-        error(f"Todo ne trovita: {referenco}")
-        raise typer.Exit(1)
-    _show_detail(item)
-
-
-@todo_app.command()
-def modifi(
-    referenco: str = typer.Argument(
-        ...,
-        help=tr_multi("Todo UUID aŭ titolo. Ekz: todo modifi #abc --stato farita", "Todo UUID or title. E.g. todo modify #abc --stato farita", "UUID ou titre du todo. Ex: todo modifier #abc --stato farita"),
-    ),
-    titolo: str | None = typer.Option(
-        None,
-        "-T",
-        "--titolo",
-        help='Nova titolo. Ekz: --titolo "Fini raporton"',
-    ),
-    priskribo: str | None = typer.Option(
-        None,
-        "-p",
-        "--priskribo",
-        help='Nova priskribo. Ekz: -p "Vidu [noto](vt#uuid)"',
-    ),
-    prioritato: str | None = typer.Option(
-        None,
-        "-P",
-        "--prioritato",
-        help='Nova prioritato. Ekz: -P "30 + 5 * (H - 10)"',
-    ),
-    stato: str | None = typer.Option(
-        None,
-        "-s",
-        "--stato",
-        help=(
-            "Nova stato. Validaj: malfermita, farita, prokrastita, nuligita. "
-            "Ekz: -s farita"
-        ),
-    ),
-    etikedo: list[str] | None = typer.Option(
-        None,
-        "-e",
-        "--etikedo",
-        help=(
-            "Nova etikedo-listo (anstataŭigas); ripetu por pluraj. "
-            "Ekz: -e #abc -e grava"
-        ),
-    ),
-) -> None:
-    """Modifi ekzistantan taskon."""
-    svc = get_todo_service()
-    entries = svc.list_with_labels(limit=200)
-    item = resolve_reference(
-        entries,
-        referenco,
-        text_getter=lambda i: str(i.get("titolo") or ""),
-        kind_label="todo",
-        allow_fuzzy=True,
-        interactive=True,
-    )
-    if item is None:
-        error(f"Todo ne trovita: {referenco}")
-        raise typer.Exit(1)
-
-    if all(
-        v is None
-        for v in (titolo, priskribo, prioritato, stato, etikedo)
-    ):
-        error("Nenio por modifi. Uzu almenaŭ unu opcion.")
-        raise typer.Exit(1)
-
-    uid = str(item.get("uuid") or "")
-    update: dict = {}
-
-    if titolo is not None:
-        new_titolo = normalize_markdown_links(titolo).strip()
-        if not new_titolo:
-            error("Malplena titolo ne permesata.")
-            raise typer.Exit(1)
-        update["titolo"] = new_titolo
-        update["titolo_norm"] = fold_search_text(new_titolo)
-
-    if priskribo is not None:
-        update["priskribo"] = normalize_markdown_links(priskribo).strip()
-        update["priskribo_norm"] = fold_search_text(update["priskribo"])
-
-    if prioritato is not None:
-        if not validate_formula(prioritato):
-            error(f"Nevalida prioritata formulo: {prioritato!r}")
-            raise typer.Exit(1)
-        update["prioritato"] = prioritato.strip()
-
-    if stato is not None:
-        update["stato"] = stato
-
-    if etikedo is not None:
-        etikedo_ids = resolve_etikedo_refs(
-            get_etikedo_service().db,
-            etikedo,
-            interactive=True,
-            prompt_on_missing=True,
-        )
-        update["etikedo"] = etikedo_ids
-
-    try:
-        svc.update(uid, update)
-    except ValueError as exc:
-        error(str(exc))
-        raise typer.Exit(1) from exc
-
-    updated = svc.get_with_labels(uid)
-    if updated is None:
-        error("Ne povis relegi modifitan taskon.")
-        raise typer.Exit(1)
-    info(f"Modifis todo #{uid[:8]}.")
-    _show_detail(updated)
-
-
-@todo_app.command()
-def forigi(
-    referencoj: Annotated[list[str], typer.Argument(
-        ...,
-        help=tr_multi("Todo UUID aŭ titolo (pluraj). Ekz: todo forigi #abc123 #def456", "Todo UUID or title (multiple). E.g. todo delete #abc123 #def456", "UUID ou titre du todo (plusieurs). Ex: todo supprimer #abc123 #def456"),
-    )],
-) -> None:
-    """Forigi taskojn laŭ UUID aŭ titolo."""
-    svc = get_todo_service()
-    entries = svc.list_with_labels(limit=200)
-
-    deleted = 0
-    errors: list[tuple[str, str]] = []
-
-    for ref in referencoj:
-        item = resolve_reference(
-            entries,
-            ref,
-            text_getter=lambda i: str(i.get("titolo") or ""),
-            kind_label="todo",
-            allow_fuzzy=True,
-            interactive=True,
-        )
-        if item is None:
-            errors.append((ref, tr_multi("ne trovita", "not found", "non trouvé")))
-            continue
-
-        uid = str(item.get("uuid") or "")
-        rendered = render_text(str(item.get("titolo") or ""))
-        answer = typer.prompt(
-            f"Forigi todo #{uid[:8]} \"{rendered}\"? (j/N)",
-            default="N",
-        )
-        if answer.strip().lower() not in {"j", "jes", "y", "yes"}:
-            info(tr_multi(f"Preterlasis {ref}.", f"Skipped {ref}.", f"Ignoré {ref}."))
-            continue
-
-        svc.delete(uid, soft=False)
-        deleted += 1
-        entries = [e for e in entries if str(e.get("uuid") or "") != uid]
-        info(f"Forigis todo #{uid[:8]}.")
-
-    # Report resolution errors
-    for ref, reason in errors:
-        error(tr_multi(
-            "Forigi {i}: {r}", "Delete {i}: {r}", "Supprimer {i} : {r}",
-        ).format(i=ref, r=reason))
-
-    if deleted:
-        info(tr_multi(
-            f"Forigis {deleted} el {len(referencoj)} todo.",
-            f"Deleted {deleted} of {len(referencoj)} todos.",
-            f"Supprimé {deleted} sur {len(referencoj)} todos.",
-        ))
-
-
-@todo_app.command()
-def serci(
-    teksto: str = typer.Argument(
-        "",
-        help=tr_multi("Serĉa teksto. Ekz: todo serci legi", "Search text. E.g. todo search read", "Texte de recherche. Ex: todo rechercher lire"),
-    ),
-    titolo: str | None = typer.Option(
-        None,
-        "--titolo",
-        help=tr_multi("Filtri laŭ titolo. Ekz: --titolo raporto", "Filter by title. E.g. --titolo report", "Filtrer par titre. Ex: --titolo rapport"),
-    ),
-    priskribo: str | None = typer.Option(
-        None,
-        "--priskribo",
-        help=tr_multi("Filtri laŭ priskribo. Ekz: --priskribo [temo](ec#uuid)", "Filter by description. E.g. --priskribo [topic](ec#uuid)", "Filtrer par description. Ex: --priskribo [sujet](ec#uuid)"),
-    ),
-    stato: str | None = typer.Option(
-        None,
-        "-s",
-        "--stato",
-        help=(
-            "Filtri laŭ stato. "
-            "Validaj: malfermita, farita, prokrastita, nuligita. "
-            "Ekz: -s farita"
-        ),
-    ),
-    etikedo: list[str] | None = typer.Option(
-        None,
-        "-e",
-        "--etikedo",
-        help=(
-            "Filtri laŭ etikedo; ripetu por pluraj. "
-            "Ekz: -e urga -e #abc"
-        ),
-    ),
-    prioritato: str | None = typer.Option(
-        None,
-        "-P",
-        "--prioritato",
-        help=tr_multi("Filtri laŭ prioritato MIN,MAX aŭ nur MIN. Ekz: -P 30,80 aŭ -P 50", "Filter by priority MIN,MAX or just MIN. E.g. -P 30,80 or -P 50", "Filtrer par priorité MIN,MAX ou juste MIN. Ex: -P 30,80 ou -P 50"),
-    ),
-    limo: int = typer.Option(
-        50,
-        "-lo",
-        "--limo",
-        help=tr_multi("Maksimumaj rezultoj. Ekz: --limo 20", "Maximum results. E.g. --limo 20", "Résultats maximum. Ex: --limo 20"),
-    ),
-) -> None:
-    """Serĉi taskojn per kombineblaj filtriloj."""
-    svc = get_todo_service()
-    etikedo_ids: list[str] = []
-    if etikedo:
-        etikedo_ids = resolve_etikedo_refs(
-            get_etikedo_service().db, etikedo, interactive=True
-        )
-
-    # Parse priority range
-    prioritato_min: float | None = None
-    prioritato_max: float | None = None
-    if prioritato:
-        raw = prioritato.strip()
-        if "," in raw:
-            left, right = raw.split(",", 1)
-            prioritato_min = float(left.strip()) if left.strip() else None
-            prioritato_max = float(right.strip()) if right.strip() else None
-        else:
-            prioritato_min = float(raw)
-
-    results, fuzzy_used = svc.search_todo(
-        query=teksto or None,
-        titolo=titolo,
-        priskribo=priskribo,
-        stato=stato,
-        etikedo=etikedo_ids or None,
-        prioritato_min=prioritato_min,
-        prioritato_max=prioritato_max,
-        limit=limo,
-    )
-
-    if fuzzy_used:
-        info("Neniu preciza rezulto; montrante similajn kongruojn.")
-    info(f"{len(results)} rezulto(j) trovita(j).")
-    if results:
-        _print_results(results)
-
-
-__all__ = ["todo_app"]
+__all__ = ["todo_app", "_print_results", "_show_detail"]

--- a/src/A_organizi/cli/todo_crud.py
+++ b/src/A_organizi/cli/todo_crud.py
@@ -1,0 +1,390 @@
+"""CRUD commands for todo (tasks) — ls, vidi, modifi, forigi, serci.
+
+Split from todo.py to keep each file under 500 lines.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+import typer
+
+from A import error, info, tr_multi
+from A.utils.normalize import fold_search_text
+
+from A_organizi.priority import (
+    compute_priority,
+    validate_formula,
+)
+from A_organizi.service import get_etikedo_service, get_todo_service
+from A_organizi.cli.todo import _print_results, _show_detail, todo_app
+from A_organizi.utils.labels import (
+    normalize_markdown_links,
+    render_markdown_links_plain as render_text,
+    resolve_etikedo_refs,
+    resolve_reference,
+)
+
+
+# ── Commands ─────────────────────────────────────────────────────────────────
+
+
+@todo_app.command()
+def ls(
+    priority: bool = typer.Option(
+        False,
+        "-p",
+        "--priority",
+        help=tr_multi(
+            "Ordigi la\u016d prioritato (desc).",
+            "Sort by priority (descending).",
+            "Trier par priorit\u00e9 (d\u00e9croissante).",
+        ),
+    ),
+    reverse: bool = typer.Option(
+        False,
+        "-r",
+        "--reverse",
+        help=tr_multi(
+            "Inversigi la ordon.",
+            "Reverse sort order.",
+            "Inverser l'ordre de tri.",
+        ),
+    ),
+) -> None:
+    """Listi \u0109iujn taskojn."""
+    svc = get_todo_service()
+    items = svc.list_with_labels(limit=200)
+
+    if not items:
+        info(tr_multi(
+            "Neniuj taskoj.",
+            "No tasks.",
+            "Aucune t\u00e2che.",
+        ))
+        return
+
+    if priority:
+        for item in items:
+            item["_priority_value"] = compute_priority(
+                str(item.get("prioritato") or "0"),
+                str(item.get("kreita_je") or ""),
+            )
+        items.sort(key=lambda x: x["_priority_value"], reverse=not reverse)
+    elif reverse:
+        items.reverse()
+
+    _print_results(items)
+
+
+@todo_app.command()
+def vidi(
+    referenco: str = typer.Argument(
+        ...,
+        help=tr_multi(
+            "Todo UUID a\u016d titolo. Ekz: todo vidi #abc123",
+            "Todo UUID or title. E.g. todo view #abc123",
+            "UUID ou titre du todo. Ex: todo voir #abc123",
+        ),
+    ),
+) -> None:
+    """Montri unu taskon la\u016d UUID a\u016d titolo."""
+    svc = get_todo_service()
+    entries = svc.list_with_labels(limit=200)
+    item = resolve_reference(
+        entries,
+        referenco,
+        text_getter=lambda i: str(i.get("titolo") or ""),
+        kind_label="todo",
+        allow_fuzzy=True,
+        interactive=True,
+    )
+    if item is None:
+        error(f"Todo ne trovita: {referenco}")
+        raise typer.Exit(1)
+    _show_detail(item)
+
+
+@todo_app.command()
+def modifi(
+    referenco: str = typer.Argument(
+        ...,
+        help=tr_multi(
+            "Todo UUID a\u016d titolo. Ekz: todo modifi #abc --stato farita",
+            "Todo UUID or title. E.g. todo modify #abc --stato farita",
+            "UUID ou titre du todo. Ex: todo modifier #abc --stato farita",
+        ),
+    ),
+    titolo: str | None = typer.Option(
+        None,
+        "-T",
+        "--titolo",
+        help='Nova titolo. Ekz: --titolo "Fini raporton"',
+    ),
+    priskribo: str | None = typer.Option(
+        None,
+        "-p",
+        "--priskribo",
+        help='Nova priskribo. Ekz: -p "Vidu [noto](vt#uuid)"',
+    ),
+    prioritato: str | None = typer.Option(
+        None,
+        "-P",
+        "--prioritato",
+        help='Nova prioritato. Ekz: -P "30 + 5 * (H - 10)"',
+    ),
+    stato: str | None = typer.Option(
+        None,
+        "-s",
+        "--stato",
+        help=(
+            "Nova stato. Validaj: malfermita, farita, prokrastita, nuligita. "
+            "Ekz: -s farita"
+        ),
+    ),
+    etikedo: list[str] | None = typer.Option(
+        None,
+        "-e",
+        "--etikedo",
+        help=(
+            "Nova etikedo-listo (anstata\u016digas); ripetu por pluraj. "
+            "Ekz: -e #abc -e grava"
+        ),
+    ),
+) -> None:
+    """Modifi ekzistantan taskon."""
+    svc = get_todo_service()
+    entries = svc.list_with_labels(limit=200)
+    item = resolve_reference(
+        entries,
+        referenco,
+        text_getter=lambda i: str(i.get("titolo") or ""),
+        kind_label="todo",
+        allow_fuzzy=True,
+        interactive=True,
+    )
+    if item is None:
+        error(f"Todo ne trovita: {referenco}")
+        raise typer.Exit(1)
+
+    if all(
+        v is None
+        for v in (titolo, priskribo, prioritato, stato, etikedo)
+    ):
+        error("Nenio por modifi. Uzu almena\u016d unu opcion.")
+        raise typer.Exit(1)
+
+    uid = str(item.get("uuid") or "")
+    update: dict = {}
+
+    if titolo is not None:
+        new_titolo = normalize_markdown_links(titolo).strip()
+        if not new_titolo:
+            error("Malplena titolo ne permesata.")
+            raise typer.Exit(1)
+        update["titolo"] = new_titolo
+        update["titolo_norm"] = fold_search_text(new_titolo)
+
+    if priskribo is not None:
+        update["priskribo"] = normalize_markdown_links(priskribo).strip()
+        update["priskribo_norm"] = fold_search_text(update["priskribo"])
+
+    if prioritato is not None:
+        if not validate_formula(prioritato):
+            error(f"Nevalida prioritata formulo: {prioritato!r}")
+            raise typer.Exit(1)
+        update["prioritato"] = prioritato.strip()
+
+    if stato is not None:
+        update["stato"] = stato
+
+    if etikedo is not None:
+        etikedo_ids = resolve_etikedo_refs(
+            get_etikedo_service().db,
+            etikedo,
+            interactive=True,
+            prompt_on_missing=True,
+        )
+        update["etikedo"] = etikedo_ids
+
+    try:
+        svc.update(uid, update)
+    except ValueError as exc:
+        error(str(exc))
+        raise typer.Exit(1) from exc
+
+    updated = svc.get_with_labels(uid)
+    if updated is None:
+        error("Ne povis relegi modifitan taskon.")
+        raise typer.Exit(1)
+    info(f"Modifis todo {uid[:8]}.")
+    _show_detail(updated)
+
+
+@todo_app.command()
+def forigi(
+    referencoj: Annotated[list[str], typer.Argument(
+        ...,
+        help=tr_multi(
+            "Todo UUID a\u016d titolo (pluraj). Ekz: todo forigi #abc123 #def456",
+            "Todo UUID or title (multiple). E.g. todo delete #abc123 #def456",
+            "UUID ou titre du todo (plusieurs). Ex: todo supprimer #abc123 #def456",
+        ),
+    )],
+) -> None:
+    """Forigi taskojn la\u016d UUID a\u016d titolo."""
+    svc = get_todo_service()
+    entries = svc.list_with_labels(limit=200)
+
+    deleted = 0
+    errors: list[tuple[str, str]] = []
+
+    for ref in referencoj:
+        item = resolve_reference(
+            entries,
+            ref,
+            text_getter=lambda i: str(i.get("titolo") or ""),
+            kind_label="todo",
+            allow_fuzzy=True,
+            interactive=True,
+        )
+        if item is None:
+            errors.append((ref, tr_multi("ne trovita", "not found", "non trouv\u00e9")))
+            continue
+
+        uid = str(item.get("uuid") or "")
+        rendered = render_text(str(item.get("titolo") or ""))
+        answer = typer.prompt(
+            f"Forigi todo {uid[:8]} \"{rendered}\"? (j/N)",
+            default="N",
+        )
+        if answer.strip().lower() not in {"j", "jes", "y", "yes"}:
+            info(tr_multi(
+                f"Preterlasis {ref}.", f"Skipped {ref}.", f"Ignor\u00e9 {ref}.",
+            ))
+            continue
+
+        svc.delete(uid, soft=False)
+        deleted += 1
+        entries = [e for e in entries if str(e.get("uuid") or "") != uid]
+        info(f"Forigis todo {uid[:8]}.")
+
+    for ref, reason in errors:
+        error(tr_multi(
+            "Forigi {i}: {r}", "Delete {i}: {r}", "Supprimer {i} : {r}",
+        ).format(i=ref, r=reason))
+
+    if deleted:
+        info(tr_multi(
+            f"Forigis {deleted} el {len(referencoj)} todo.",
+            f"Deleted {deleted} of {len(referencoj)} todos.",
+            f"Supprim\u00e9 {deleted} sur {len(referencoj)} todos.",
+        ))
+
+
+@todo_app.command()
+def serci(
+    teksto: str = typer.Argument(
+        "",
+        help=tr_multi(
+            "Ser\u0109a teksto. Ekz: todo serci legi",
+            "Search text. E.g. todo search read",
+            "Texte de recherche. Ex: todo rechercher lire",
+        ),
+    ),
+    titolo: str | None = typer.Option(
+        None,
+        "--titolo",
+        help=tr_multi(
+            "Filtri la\u016d titolo. Ekz: --titolo raporto",
+            "Filter by title. E.g. --titolo report",
+            "Filtrer par titre. Ex: --titolo rapport",
+        ),
+    ),
+    priskribo: str | None = typer.Option(
+        None,
+        "--priskribo",
+        help=tr_multi(
+            "Filtri la\u016d priskribo. Ekz: --priskribo [temo](ec#uuid)",
+            "Filter by description. E.g. --priskribo [topic](ec#uuid)",
+            "Filtrer par description. Ex: --priskribo [sujet](ec#uuid)",
+        ),
+    ),
+    stato: str | None = typer.Option(
+        None,
+        "-s",
+        "--stato",
+        help=(
+            "Filtri la\u016d stato. "
+            "Validaj: malfermita, farita, prokrastita, nuligita. "
+            "Ekz: -s farita"
+        ),
+    ),
+    etikedo: list[str] | None = typer.Option(
+        None,
+        "-e",
+        "--etikedo",
+        help=(
+            "Filtri la\u016d etikedo; ripetu por pluraj. "
+            "Ekz: -e urga -e #abc"
+        ),
+    ),
+    prioritato: str | None = typer.Option(
+        None,
+        "-P",
+        "--prioritato",
+        help=tr_multi(
+            "Filtri la\u016d prioritato MIN,MAX a\u016d nur MIN. Ekz: -P 30,80 a\u016d -P 50",
+            "Filter by priority MIN,MAX or just MIN. E.g. -P 30,80 or -P 50",
+            "Filtrer par priorit\u00e9 MIN,MAX ou juste MIN. Ex: -P 30,80 ou -P 50",
+        ),
+    ),
+    limo: int = typer.Option(
+        50,
+        "-lo",
+        "--limo",
+        help=tr_multi(
+            "Maksimumaj rezultoj. Ekz: --limo 20",
+            "Maximum results. E.g. --limo 20",
+            "R\u00e9sultats maximum. Ex: --limo 20",
+        ),
+    ),
+) -> None:
+    """Ser\u0109i taskojn per kombineblaj filtriloj."""
+    svc = get_todo_service()
+    etikedo_ids: list[str] = []
+    if etikedo:
+        etikedo_ids = resolve_etikedo_refs(
+            get_etikedo_service().db, etikedo, interactive=True
+        )
+
+    prioritato_min: float | None = None
+    prioritato_max: float | None = None
+    if prioritato:
+        raw = prioritato.strip()
+        if "," in raw:
+            left, right = raw.split(",", 1)
+            prioritato_min = float(left.strip()) if left.strip() else None
+            prioritato_max = float(right.strip()) if right.strip() else None
+        else:
+            prioritato_min = float(raw)
+
+    results, fuzzy_used = svc.search_todo(
+        query=teksto or None,
+        titolo=titolo,
+        priskribo=priskribo,
+        stato=stato,
+        etikedo=etikedo_ids or None,
+        prioritato_min=prioritato_min,
+        prioritato_max=prioritato_max,
+        limit=limo,
+    )
+
+    if fuzzy_used:
+        info("Neniu preciza rezulto; montrante similajn kongruojn.")
+    info(f"{len(results)} rezulto(j) trovita(j).")
+    if results:
+        _print_results(results)
+
+
+__all__: list[str] = []

--- a/tests/test_todo.py
+++ b/tests/test_todo.py
@@ -336,7 +336,7 @@ class TestTodoCLI:
         runner.invoke(app, ["todo", "aldoni", "Videbla tasko", "-P", "10"])
         result = runner.invoke(app, ["todo", "vidi", "Videbla tasko"])
         assert result.exit_code == 0, result.output
-        assert "uuid:" in result.output
+        assert "Videbla tasko" in result.output
 
     def test_vidi_not_found(self):
         """View non-existent task returns error."""
@@ -424,6 +424,73 @@ class TestTodoCLI:
         assert result.exit_code == 0
         assert "ne trovita" in result.output.lower() or "not found" in result.output.lower()
 
+    def test_ls_empty(self):
+        """List when no tasks exist."""
+        from typer.testing import CliRunner
+        from A_organizi.cli import app
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["todo", "ls"])
+        assert result.exit_code == 0, result.output
+        assert "Neniuj" in result.output or "No tasks" in result.output
+
+    def test_ls(self):
+        """List all tasks."""
+        from typer.testing import CliRunner
+        from A_organizi.cli import app
+
+        runner = CliRunner()
+        runner.invoke(app, ["todo", "aldoni", "Unua", "-P", "10"])
+        runner.invoke(app, ["todo", "aldoni", "Dua", "-P", "20"])
+        result = runner.invoke(app, ["todo", "ls"])
+        assert result.exit_code == 0, result.output
+        assert "Unua" in result.output
+        assert "Dua" in result.output
+
+    def test_ls_priority(self):
+        """List sorted by priority."""
+        from typer.testing import CliRunner
+        from A_organizi.cli import app
+
+        runner = CliRunner()
+        runner.invoke(app, ["todo", "aldoni", "Malalta", "-P", "10"])
+        runner.invoke(app, ["todo", "aldoni", "Alta", "-P", "90"])
+        result = runner.invoke(app, ["todo", "ls", "-p"])
+        assert result.exit_code == 0, result.output
+        # Higher priority should appear first
+        alta_idx = result.output.index("Alta")
+        malalta_idx = result.output.index("Malalta")
+        assert alta_idx < malalta_idx, "Higher priority should sort first"
+
+    def test_ls_priority_reverse(self):
+        """List sorted by priority ascending (reverse)."""
+        from typer.testing import CliRunner
+        from A_organizi.cli import app
+
+        runner = CliRunner()
+        runner.invoke(app, ["todo", "aldoni", "Malalta", "-P", "10"])
+        runner.invoke(app, ["todo", "aldoni", "Alta", "-P", "90"])
+        result = runner.invoke(app, ["todo", "ls", "-p", "-r"])
+        assert result.exit_code == 0, result.output
+        # Lower priority should appear first when reversed
+        alta_idx = result.output.index("Alta")
+        malalta_idx = result.output.index("Malalta")
+        assert malalta_idx < alta_idx, "Lower priority should sort first when reversed"
+
+    def test_ls_reverse(self):
+        """List with reverse order (oldest first)."""
+        from typer.testing import CliRunner
+        from A_organizi.cli import app
+
+        runner = CliRunner()
+        runner.invoke(app, ["todo", "aldoni", "Unua", "-P", "10"])
+        runner.invoke(app, ["todo", "aldoni", "Dua", "-P", "20"])
+        result = runner.invoke(app, ["todo", "ls", "-r"])
+        assert result.exit_code == 0, result.output
+        # Both titles should still appear
+        assert "Unua" in result.output
+        assert "Dua" in result.output
+
     def test_serci(self):
         """Search tasks."""
         from typer.testing import CliRunner
@@ -479,6 +546,7 @@ class TestTodoCLI:
         runner = CliRunner()
         result = runner.invoke(app, ["todo", "--help"])
         assert result.exit_code == 0
+        assert "ls" in result.output
         assert "aldoni" in result.output
         assert "vidi" in result.output
         assert "modifi" in result.output


### PR DESCRIPTION
Closes #38

- Add `ls` command with -p/--priority and -r/--reverse sort options
- Strip `#` from UUID display in all todo commands
- Convert `vidi` to Rich Panel display
- Split todo.py into todo.py + todo_crud.py (stays under 500 lines)